### PR TITLE
Removed libmariadbclient-dev package

### DIFF
--- a/docs/linux-requirements.md
+++ b/docs/linux-requirements.md
@@ -17,7 +17,7 @@
 AzerothCore does only support MariaDB versions 10.6 and 10.5.
 
 ```sh
-sudo apt update && sudo apt full-upgrade -y && sudo apt install git cmake make gcc g++ clang libssl-dev libbz2-dev libreadline-dev libncurses-dev libboost-all-dev mariadb-server mariadb-client libmariadb-dev libmariadbclient-dev libmariadb-dev-compat
+sudo apt update && sudo apt full-upgrade -y && sudo apt install git cmake make gcc g++ clang libssl-dev libbz2-dev libreadline-dev libncurses-dev libboost-all-dev mariadb-server mariadb-client libmariadb-dev libmariadb-dev-compat
 ```
 
 #### Ubuntu with MySQL 8.x


### PR DESCRIPTION
### Description
The package "libmariadbclient-dev" package has been removed in MariaDB 10.5 and installing it will fail if you have MariaDB 10.5 or newer. Its functionalities have thus been implemented into the "libmariadb-dev" package.
